### PR TITLE
Fix image not found error on CWRC embedded Plot-It

### DIFF
--- a/assets/styles/components/filters/text_filter.css
+++ b/assets/styles/components/filters/text_filter.css
@@ -17,7 +17,7 @@ text_filter input {
 
    padding: 0.75em 3em 0.75em 0.5em;
 
-   background: #eff0ef url(/assets/images/loupe.svg) no-repeat scroll 95% 0.6em;
+   background: #eff0ef url(../../../images/loupe.svg) no-repeat scroll 95% 0.6em;
    font-family: "Lato", "Arial", sans-serif;
    font-size: 0.8em;
 }


### PR DESCRIPTION
Would this work? The CSS assumes that Plot-It is hosted at the root and this changes makes it more relative for the embedded version. 
